### PR TITLE
hashtag sick directive

### DIFF
--- a/angularSlideables.js
+++ b/angularSlideables.js
@@ -23,7 +23,7 @@ angular.module('angularSlideables', [])
             
             var expanded = false;
             scope.$on('slideToggle', function(e, data) {
-                if(data.id == attrs.id) {
+                if(data.id == '#'+attrs.id) {
                     if(!expanded) {
                         var content = element.find('div')[0];
                         content.style.border = '1px solid rgba(0,0,0,0)';


### PR DESCRIPTION
cool repo, but I would add the hashtag because it's normal to find elements that way with jQuery or Zepto, plus there's a hashtag derp derpping out in the readme example:  `<h1 slide-toggle="#derp" >Click here for Hipster Ipsum.</h1>`
