### PR TITLE
Fixed a bug with generated slideable id

### DIFF
--- a/angularSlideables.js
+++ b/angularSlideables.js
@@ -26,10 +26,14 @@ angular.module('angularSlideables', [])
     return {
         restrict: 'A',
         link: function(scope, element, attrs) {
-            var target = document.querySelector(attrs.slideToggle),
-                content = target.querySelector('.slideable_content');
+            var target, content;
+            
             attrs.expanded = false;
+            
             element.bind('click', function() {
+                if (!target) target = document.querySelector(attrs.slideToggle);
+                if (!content) content = target.querySelector('.slideable_content');
+                
                 if(!attrs.expanded) {
                     content.style.border = '1px solid rgba(0,0,0,0)';
                     var y = content.clientHeight;


### PR DESCRIPTION
The last optimizations were preventing to use the directive in a `ng-repeat` directive when the `.slideable` element `id` attribute was generated. e.g. `id="item-{{$index}}"`
