### PR TITLE
Enhancements for styling and using angularSlideables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ USAGE:
 
 Link to the library in your index (or require.js), and add 'angularSlideables' to your app modules.
 
-No CSS is necessary. Add the “slideable” class to any hidden, slideable content. Add a slide-toggle attribute to any trigger.
+No CSS is necessary. Add the “slideable” class or attribute to any hidden, slideable content. Add a slide-toggle attribute to any trigger.
 
 This directive currently only works on single targetted IDs. I’ll expand it to cover classes if there’s demand.
 

--- a/angularSlideables.js
+++ b/angularSlideables.js
@@ -1,7 +1,7 @@
 angular.module('angularSlideables', [])
 .directive('slideable', function () {
     return {
-        restrict:'C',
+        restrict:'CA',
         compile: function (element, attr) {
             // wrap tag
             var contents = element.html();

--- a/angularSlideables.js
+++ b/angularSlideables.js
@@ -34,6 +34,14 @@ angular.module('angularSlideables', [])
                 if (!target) target = document.querySelector(attrs.slideToggle);
                 if (!content) content = target.querySelector('.slideable_content');
                 
+                target.addEventListener('transitionend',function() {
+                	if (attrs.expanded) {
+                		element.addClass("expanded");
+                	} else {
+                		element.removeClass("expanded");
+                	}
+                });
+				
                 if(!attrs.expanded) {
                     content.style.border = '1px solid rgba(0,0,0,0)';
                     var y = content.clientHeight;
@@ -45,5 +53,5 @@ angular.module('angularSlideables', [])
                 attrs.expanded = !attrs.expanded;
             });
         }
-    }
+    };
 });


### PR DESCRIPTION
- Can now use slideable as an attribute directive
- The slider toggle now gains a class "expanded" when the slideable is open. This allows you to style the slider toggle with, for example, an up/down caret.
